### PR TITLE
Throw on JSON.stringify of an Integer

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -1421,7 +1421,45 @@ emu-integration-plans:before {
       </emu-clause>
     </emu-clause>
   </emu-clause>
-</emu-clause>
+
+<emu-clause id="sec-modifications">
+  <h1>Modified algorithms</h1>
+      <!-- es6num="24.3.2.1" -->
+      <emu-clause id="sec-serializejsonproperty" aoid="SerializeJSONProperty">
+        <h1>Runtime Semantics: SerializeJSONProperty ( _key_, _holder_ )</h1>
+        <p>The abstract operation SerializeJSONProperty with arguments _key_, and _holder_ has access to _ReplacerFunction_ from the invocation of the `stringify` method. Its algorithm is as follows:</p>
+        <emu-alg>
+          1. Let _value_ be ? Get(_holder_, _key_).
+          1. If Type(_value_) is Object, then
+            1. Let _toJSON_ be ? Get(_value_, `"toJSON"`).
+            1. If IsCallable(_toJSON_) is *true*, then
+              1. Set _value_ to ? Call(_toJSON_, _value_, &laquo; _key_ &raquo;).
+          1. If _ReplacerFunction_ is not *undefined*, then
+            1. Set _value_ to ? Call(_ReplacerFunction_, _holder_, &laquo; _key_, _value_ &raquo;).
+          1. If Type(_value_) is Object, then
+            1. If _value_ has a [[NumberData]] internal slot, then
+              1. Set _value_ to ? ToNumber(_value_).
+            1. Else if _value_ has a [[StringData]] internal slot, then
+              1. Set _value_ to ? ToString(_value_).
+            1. Else if _value_ has a [[BooleanData]] internal slot, then
+              1. Set _value_ to _value_.[[BooleanData]].
+            1. <ins>Else if _value_ has a [[IntegerData]] internal slot, then</ins>
+              1. <ins>Set _value_ to _value_.[[IntegerData]].</ins>
+          1. If _value_ is *null*, return `"null"`.
+          1. If _value_ is *true*, return `"true"`.
+          1. If _value_ is *false*, return `"false"`.
+          1. If Type(_value_) is String, return QuoteJSONString(_value_).
+          1. If Type(_value_) is Number, then
+            1. If _value_ is finite, return ! ToString(_value_).
+            1. Else, return `"null"`.
+          1. If Type(_value_) is Object and IsCallable(_value_) is *false*, then
+            1. Let _isArray_ be ? IsArray(_value_).
+            1. If _isArray_ is *true*, return ? SerializeJSONArray(_value_).
+            1. Else, return ? SerializeJSONObject(_value_).
+          1. <ins>If Type(_value_) is Integer, throw a *TypeError* exception.</ins>
+          1. Return *undefined*.
+        </emu-alg>
+      </emu-clause>
 
       <!-- es6num="20.1.1.1" -->
       <emu-clause id="sec-number-constructor-number-value">
@@ -1441,6 +1479,7 @@ emu-integration-plans:before {
         <emu-note>See <emu-xref href="#sec-ecmascript-language-types-number-type"></emu-xref> in the second-to-last paragraph for the definition of the phrase "The Number value for _integer_".</emu-note>
         <emu-integration-plans>That paragraph should possibly be refactored into a separate abstract operation; see <a href="https://github.com/littledan/proposal-integer/issues/10">this bug</a> for more discussion about the integration of different numeric types and casting operations between them.</emu-integration-plans>
       </emu-clause>
+</emu-clause>
 
 <emu-clause id="sec-typedarrays-and-dataview">
   <h1>TypedArrays and DataViews</h1>


### PR DESCRIPTION
To future-proof against possible ways we could allow Integer in JSON,
this patch bans them for now. This option contrasts with Symbols,
which show up as missing in JSON object serialization. It's expected
that it will take longer to get Integer into a version of JSON than
it will to get Integer into browsers in memory, and that we don't
want to block the second on the first.

Relates to #24, but leaving that bug open to discuss the future
beyond the initial throwing plan.

What do you think, @bterlson @rwaldron @ljharb @bakkot @rauschma @claudepache @MaxArt2501 @kgyrte @leobalter ?